### PR TITLE
Scala 2x library should still be shipped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	include(api("org.scala-lang:scala3-library_3:${detected_scala_version}"))
+	include(api("org.scala-lang:scala-library:2.13.12"))
 }
 
 processResources {


### PR DESCRIPTION
The Scala 2x library should still be shipped as it provides important classes like FunctionN and TupleN. Using them in mod code will throw a ClassDefNotFoundError without the 2x libraries. Sample error:

```
Caused by: java.lang.NoClassDefFoundError: scala/Function1
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:534)
	at java.base/java.lang.Class.forName(Class.java:513)
	at knot//net.fabricmc.language.scala.ScalaLanguageAdapter.getScalaObject(ScalaLanguageAdapter.java:33)
	at knot//net.fabricmc.language.scala.ScalaLanguageAdapter.create(ScalaLanguageAdapter.java:20)
	at net.fabricmc.loader.impl.entrypoint.EntrypointStorage$NewEntry.getOrCreate(EntrypointStorage.java:124)
	at net.fabricmc.loader.impl.entrypoint.EntrypointContainerImpl.getEntrypoint(EntrypointContainerImpl.java:53)
	at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:399)
	... 9 more